### PR TITLE
Update maltrail_installer.sh

### DIFF
--- a/maltrail_installer.sh
+++ b/maltrail_installer.sh
@@ -88,10 +88,10 @@ function install_maltrail () {
 
 	# Install Dependency packages to support MalTrail
 	echo " "
-	print_status "Installing Python-pcapy to support Maltrail..."
-	sudo apt-get install python-pcapy -y &>> $logfile
+	print_status "Installing Python-pcapy-ng to support Maltrail..."
+	sudo pip3 install pcapy-ng &>> $logfile
 	echo " "
-	error_check "Installation of python-pcapy..."
+	error_check "Installation of python-pcapy-ng..."
 
 	# Download and install Maltrail
 	echo " "


### PR DESCRIPTION
python-pcapy is no longer supported. python-pcapy-ng only, which provides compability with Python 3.10 and fixes Maltrail's OOM on *BSD-line. See https://github.com/stamparm/maltrail/blob/master/requirements.txt